### PR TITLE
feat: change user query api to search by username as well

### DIFF
--- a/src/helpers/testHelper.ts
+++ b/src/helpers/testHelper.ts
@@ -2,19 +2,26 @@ import { finalizeEvent, generateSecretKey, getPublicKey, nip19, nip98 } from "no
 import { Account } from "../services/AccountService";
 
 export const generateNIP98 = async (method = 'GET') => {
-  const sk = generateSecretKey()
-  const pubkey = getPublicKey(sk)
-  const token = await nip98.getToken('http://localhost:3000/api/account', method, e => finalizeEvent(e, sk))
+  const keyPair = generateKeyPair()
+  const token = await nip98.getToken('http://localhost:3000/api/account', method, e => finalizeEvent(e, keyPair.privateKey))
   return {
-    privateKey: sk,
-    pubkey,
-    npub: nip19.npubEncode(pubkey),
+    ...keyPair,
     token,
   };
 };
 
+export const generateKeyPair = () => {
+  const sk = generateSecretKey()
+  const pubkey = getPublicKey(sk)
+  return {
+    privateKey: sk,
+    pubkey,
+    npub: nip19.npubEncode(pubkey),
+  }
+}
+
 export const testAccount = (partial?: { pubkey?: string, email?: string, username?: string }): Account => ({
-  pubkey: 'npub1test123456789',
+  pubkey: generateKeyPair().npub,
   email: 'test@email.com',
   username: 'bla',
   createdAt: new Date(),

--- a/src/routes/account.test.ts
+++ b/src/routes/account.test.ts
@@ -31,7 +31,7 @@ describe('Account API', () => {
     jest.resetAllMocks();
   });
 
-  describe('GET /api/account/:pubkey', () => {
+  describe('GET /api/account/:pubkeyOrUsername', () => {
     test('should check if pubkey is not available', async () => {
       accountService.getAccount.mockResolvedValueOnce(account)
 
@@ -56,6 +56,33 @@ describe('Account API', () => {
         .expect(404);
 
       expect(accountService.getAccount).toHaveBeenCalledWith(account.pubkey);
+    });
+
+    test('should check if username is not available', async () => {
+      accountService.getAccountByUsername.mockResolvedValueOnce(account)
+
+      const response = await request(app)
+        .get(`/api/account/${account.username}`)
+        .expect(200);
+
+      expect(accountService.getAccountByUsername).toHaveBeenCalledWith(account.username)
+      expect(response.body).toEqual({
+        pubkey: account.pubkey,
+        signupDate: account.createdAt.toISOString(),
+        tier: 'free',
+        isActive: true,
+      });
+    });
+
+    test('should check if username is available', async () => {
+      accountService.getAccountByUsername.mockResolvedValueOnce(null)
+
+      await request(app)
+        .get(`/api/account/${account.username}`)
+        .expect(404);
+
+      expect(accountService.getAccount).not.toHaveBeenCalled()
+      expect(accountService.getAccountByUsername).toHaveBeenCalledWith(account.username);
     });
 
     test('should return 400 for invalid pubkey format', async () => {

--- a/src/services/AccountService.ts
+++ b/src/services/AccountService.ts
@@ -75,6 +75,21 @@ class AccountService extends BaseTableStorageService<Account> {
   async getAccount(pubkey: string): Promise<Account | null> {
     return this.getEntity('account', pubkey)
   }
+
+  async getAccountByUsername(username: string): Promise<Account | null> {
+    try {
+      const filter = `username eq '${username}'`;
+      const iterator = this.tableClient.listEntities<TableEntity<Account>>({ queryOptions: { filter } });
+      
+      for await (const entity of iterator) {
+        return toAccount(entity);
+      }
+      
+      return null;
+    } catch (error) {
+      throw new Error(`Failed to get account by username: ${(error as Error).message}`);
+    }
+  }
 }
 
 export default new AccountService();

--- a/src/services/AccountService.ts
+++ b/src/services/AccountService.ts
@@ -78,14 +78,8 @@ class AccountService extends BaseTableStorageService<Account> {
 
   async getAccountByUsername(username: string): Promise<Account | null> {
     try {
-      const filter = `username eq '${username}'`;
-      const iterator = this.tableClient.listEntities<TableEntity<Account>>({ queryOptions: { filter } });
-      
-      for await (const entity of iterator) {
-        return toAccount(entity);
-      }
-      
-      return null;
+      const entities = await this.queryEntities(`username eq '${username}'`);      
+      return entities.length > 0 ? entities[0] : null;
     } catch (error) {
       throw new Error(`Failed to get account by username: ${(error as Error).message}`);
     }

--- a/src/services/AccountService.ts
+++ b/src/services/AccountService.ts
@@ -78,6 +78,9 @@ class AccountService extends BaseTableStorageService<Account> {
 
   async getAccountByUsername(username: string): Promise<Account | null> {
     try {
+      // Ineffective query.
+      // TODO: either needs a second row `{ rowKey: username, pubkey }` and 
+      // then a second query or move to Cosmos DB with secondary index on `username`
       const entities = await this.queryEntities(`username eq '${username}'`);      
       return entities.length > 0 ? entities[0] : null;
     } catch (error) {

--- a/src/services/AccountService.ts
+++ b/src/services/AccountService.ts
@@ -1,4 +1,4 @@
-import BaseTableStorageService from "./BaseTableStorageService";
+import BaseTableStorageService, { escapeODataValue } from "./BaseTableStorageService";
 
 export interface Account {
   pubkey: string;
@@ -39,8 +39,8 @@ class AccountService extends BaseTableStorageService<Account> {
     try {
       // Query for any account with this username, excluding the current account if specified
       const filter = excludePubkey
-        ? `username eq '${username}' and rowKey ne '${excludePubkey}'`
-        : `username eq '${username}'`;
+        ? `username eq ${escapeODataValue(username)} and rowKey ne ${escapeODataValue(excludePubkey)}`
+        : `username eq ${escapeODataValue(username)}`;
 
       const entities = await this.queryEntities(filter);
       return entities.length > 0;
@@ -81,7 +81,7 @@ class AccountService extends BaseTableStorageService<Account> {
       // Ineffective query.
       // TODO: either needs a second row `{ rowKey: username, pubkey }` and 
       // then a second query or move to Cosmos DB with secondary index on `username`
-      const entities = await this.queryEntities(`username eq '${username}'`);      
+      const entities = await this.queryEntities(`username eq ${escapeODataValue(username)}`);
       return entities.length > 0 ? entities[0] : null;
     } catch (error) {
       throw new Error(`Failed to get account by username: ${(error as Error).message}`);

--- a/src/services/BaseTableStorageService.ts
+++ b/src/services/BaseTableStorageService.ts
@@ -1,6 +1,22 @@
-import { TableClient, TableServiceClient, TableEntityQueryOptions, TableEntityResult, TableEntity } from "@azure/data-tables";
+import { TableClient, TableServiceClient, TableEntityQueryOptions, TableEntityResult, TableEntity, odata } from "@azure/data-tables";
 import { DefaultAzureCredential } from "@azure/identity";
 import logger from "../utils/logger";
+
+type ValueType = string | Date | boolean | number
+
+export const escapeODataValue = (value: ValueType): string => {
+  if (typeof value === "string") {
+    return `'${value.replace(/'/g, "''")}'`;
+  } else if (value instanceof Date) {
+    return `datetime'${value.toISOString()}'`;
+  } else if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  } else if (typeof value === "number") {
+    return value.toString();
+  } else {
+    throw new Error("Unsupported filter value type");
+  }
+}
 
 export class BaseTableStorageService<T extends object> {
   protected tableName: string;

--- a/src/services/BaseTableStorageService.ts
+++ b/src/services/BaseTableStorageService.ts
@@ -1,4 +1,4 @@
-import { TableClient, TableServiceClient, TableEntityQueryOptions, TableEntityResult, TableEntity, odata } from "@azure/data-tables";
+import { TableClient, TableServiceClient, TableEntityQueryOptions, TableEntityResult, TableEntity } from "@azure/data-tables";
 import { DefaultAzureCredential } from "@azure/identity";
 import logger from "../utils/logger";
 

--- a/src/utils/nostr.test.ts
+++ b/src/utils/nostr.test.ts
@@ -1,0 +1,37 @@
+import { isValidNpub } from './nostr';
+
+describe('isValidNpub', () => {
+  test('should return true for valid npub format', () => {
+    const validNpub = 'npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9';
+    expect(isValidNpub(validNpub)).toBe(true);
+  });
+
+  test('should return false for invalid npub format', () => {
+    const invalidNpubs = [
+      'invalid-npub',
+      'npub1invalid',
+      'npub1',
+      'npub',
+      '',
+      'npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9invalid',
+      'npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9!',
+      'npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9 ',
+      ' npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9',
+    ];
+
+    invalidNpubs.forEach(npub => {
+      expect(isValidNpub(npub)).toBe(false);
+    });
+  });
+
+  test('should handle non-string inputs', () => {
+    // @ts-ignore - Testing invalid input types
+    expect(isValidNpub(null)).toBe(false);
+    // @ts-ignore - Testing invalid input types
+    expect(isValidNpub(undefined)).toBe(false);
+    // @ts-ignore - Testing invalid input types
+    expect(isValidNpub(123)).toBe(false);
+    // @ts-ignore - Testing invalid input types
+    expect(isValidNpub({})).toBe(false);
+  });
+});

--- a/src/utils/nostr.ts
+++ b/src/utils/nostr.ts
@@ -1,0 +1,10 @@
+import { bech32 } from '@scure/base';
+
+export const isValidNpub = (npub: string): boolean => {
+  try {
+    bech32.decode(npub);
+    return true;
+  } catch (_err) {
+    return false;
+  }
+};

--- a/src/utils/nostr.ts
+++ b/src/utils/nostr.ts
@@ -2,8 +2,8 @@ import { bech32 } from '@scure/base';
 
 export const isValidNpub = (npub: string): boolean => {
   try {
-    bech32.decode(npub);
-    return true;
+    const { prefix } = bech32.decode(npub);
+    return prefix === 'npub';
   } catch (_err) {
     return false;
   }


### PR DESCRIPTION
Changed /api/account/:pubkey to /api/account/:pubkeyOrUsername

If provided needle is npub-like do the search by npub, otherwise treat needle as a username